### PR TITLE
Avoid crashes from conflicts between BPBReachability and CDVReachability

### DIFF
--- a/src/ios/CDVReachability.m
+++ b/src/ios/CDVReachability.m
@@ -235,10 +235,10 @@ static void CDVReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRe
         return retVal;
     }
     @catch (NSException *exception) {
-        NSLog(@“%@“, exception.reason);
+        NSLog(@"%@", exception.reason);
     }
     @finally {
-        NSLog(@“It just works!”);
+        NSLog(@"It just works!");
     }
 }
 

--- a/src/ios/CDVReachability.m
+++ b/src/ios/CDVReachability.m
@@ -225,13 +225,21 @@ static void CDVReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRe
 
 - (NetworkStatus)currentReachabilityStatus
 {
-    NSAssert(reachabilityRef != NULL, @"currentNetworkStatus called with NULL reachabilityRef");
-    NetworkStatus retVal = NotReachable;
-    SCNetworkReachabilityFlags flags;
-    if (SCNetworkReachabilityGetFlags(reachabilityRef, &flags)) {
-        retVal = [self networkStatusForFlags:flags];
+    @try {
+        NSAssert(reachabilityRef != NULL, @"currentNetworkStatus called with NULL reachabilityRef");
+        NetworkStatus retVal = NotReachable;
+        SCNetworkReachabilityFlags flags;
+        if (SCNetworkReachabilityGetFlags(reachabilityRef, &flags)) {
+            retVal = [self networkStatusForFlags:flags];
+        }
+        return retVal;
     }
-    return retVal;
+    @catch (NSException *exception) {
+        NSLog(@“%@“, exception.reason);
+    }
+    @finally {
+        NSLog(@“It just works!”);
+    }
 }
 
 @end

--- a/src/ios/CDVReachability.m
+++ b/src/ios/CDVReachability.m
@@ -97,11 +97,17 @@ static void CDVReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRe
 
     // We're on the main RunLoop, so an NSAutoreleasePool is not necessary, but is added defensively
     // in case someon uses the Reachability object in a different thread.
-    @autoreleasepool {
-        CDVReachability* noteObject = (__bridge CDVReachability*)info;
-        // Post a notification to notify the client that the network reachability changed.
-        [[NSNotificationCenter defaultCenter] postNotificationName:kReachabilityChangedNotification object:noteObject];
-    }
+    // *** As this would let BPB / FotoappSDK crash, we do not pass on our CDVReachability
+    //    @autoreleasepool {
+    //        CDVReachability* noteObject = (__bridge CDVReachability*)info;
+    //        // Post a notification to notify the client that the network reachability changed.
+    //        [[NSNotificationCenter defaultCenter] postNotificationName:kReachabilityChangedNotification object:noteObject];
+    //    }
+}
+
+- (NetworkStatus)currentBPBReachabilityStatus
+{
+    return [self currentReachabilityStatus];
 }
 
 - (BOOL)startNotifier
@@ -236,9 +242,7 @@ static void CDVReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRe
     }
     @catch (NSException *exception) {
         NSLog(@"%@", exception.reason);
-    }
-    @finally {
-        NSLog(@"It just works!");
+        return 0;
     }
 }
 


### PR DESCRIPTION
Build https://github.com/SDA-SE/kundenapp-ui/pull/546 including the reference to this fork for _cordova-plugin-network_ (this is the case in the branches' `package.json`, so no need to change anything) 
**with _fotoapp_ as `PLUGIN=` in your local `.env` file.**

Ensure no crashes occur when running the app and at any point changing from or to airplane mode.